### PR TITLE
Fix typo in attribute name

### DIFF
--- a/button.py
+++ b/button.py
@@ -5,7 +5,7 @@ class Button:
 		#Core attributes 
 		self.pressed = False
 		self.elevation = elevation
-		self.dynamic_elecation = elevation
+		self.dynamic_elevation = elevation
 		self.original_y_pos = pos[1]
 
 		# top rectangle 
@@ -21,11 +21,11 @@ class Button:
 
 	def draw(self):
 		# elevation logic 
-		self.top_rect.y = self.original_y_pos - self.dynamic_elecation
+		self.top_rect.y = self.original_y_pos - self.dynamic_elevation
 		self.text_rect.center = self.top_rect.center 
 
 		self.bottom_rect.midtop = self.top_rect.midtop
-		self.bottom_rect.height = self.top_rect.height + self.dynamic_elecation
+		self.bottom_rect.height = self.top_rect.height + self.dynamic_elevation
 
 		pygame.draw.rect(screen,self.bottom_color, self.bottom_rect,border_radius = 12)
 		pygame.draw.rect(screen,self.top_color, self.top_rect,border_radius = 12)
@@ -37,15 +37,15 @@ class Button:
 		if self.top_rect.collidepoint(mouse_pos):
 			self.top_color = '#D74B4B'
 			if pygame.mouse.get_pressed()[0]:
-				self.dynamic_elecation = 0
+				self.dynamic_elevation = 0
 				self.pressed = True
 			else:
-				self.dynamic_elecation = self.elevation
+				self.dynamic_elevation = self.elevation
 				if self.pressed == True:
 					print('click')
 					self.pressed = False
 		else:
-			self.dynamic_elecation = self.elevation
+			self.dynamic_elevation = self.elevation
 			self.top_color = '#475F77'
 
 pygame.init()


### PR DESCRIPTION
Changed the spelling of a Button class attribute from 'dynamic_elecation' to 'dynamic_elevation'.